### PR TITLE
Fix building with rocksdb and artifact caching

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,11 +5,3 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "link-arg=--target=x86_64-unk
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "link-arg=--target=aarch64-unknown-linux-gnu"]
-
-[target.x86_64-unknown-linux-musl]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "link-arg=--target=x86_64-unknown-linux-musl"]
-
-[target.aarch64-unknown-linux-musl]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "link-arg=--target=aarch64-unknown-linux-musl"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@
 # the build output.
 *
 
-!target/*/release/server
+!target-*/*/release/server

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -29,64 +29,35 @@ jobs:
       - name: Install mold
         uses: rui314/setup-mold@v1
 
-      - name: Install development packages (x86_64)
-        if: matrix.arch == 'x86_64'
+      - name: Install development packages
         run: |-
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends clang musl-dev protobuf-compiler
-
-      - name: Install development packages (aarch64)
-        if: matrix.arch == 'aarch64'
-        run: |-
-          UBUNTU_VERSION=`lsb_release -cs`
-
-          # Add arm64 package archive sources
-          sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null << EOF
-          Types: deb
-          URIs: http://archive.ubuntu.com/ubuntu/
-          Suites: ${UBUNTU_VERSION} ${UBUNTU_VERSION}-updates ${UBUNTU_VERSION}-backports
-          Components: main universe restricted multiverse
-          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          Architectures: amd64
-
-          Types: deb
-          URIs: http://archive.ubuntu.com/ubuntu/
-          Suites: ${UBUNTU_VERSION}-security
-          Components: main universe restricted multiverse
-          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          Architectures: amd64
-
-          Types: deb
-          URIs: http://ports.ubuntu.com/ubuntu-ports/
-          Suites: ${UBUNTU_VERSION} ${UBUNTU_VERSION}-updates ${UBUNTU_VERSION}-backports ${UBUNTU_VERSION}-security
-          Components: main restricted universe multiverse
-          Architectures: arm64
+          # Skip installing package docs to improve GHA ubuntu times
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
           EOF
 
-          # Enable the arm64 architecture
-          sudo dpkg --add-architecture arm64
-
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends clang musl-dev:arm64 protobuf-compiler
+          sudo apt-get install -y --no-install-recommends clang protobuf-compiler
 
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.arch }}-unknown-linux-musl
-          cache-target: ${{ matrix.arch }}-unknown-linux-musl/release
+          cache-target: target-${{ matrix.arch }}
+          target-dirs: .
+
+      - name: Install musl toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.arch }}-unknown-linux-musl
 
       - name: Build Server package
-        env:
-          # ring overrides cargo's compilation settings and attempts to use gcc. But when we are cross-compiling we
-          # don't have easy access to a cross, musl gcc. Force it to use clang, just like we set in .cargo/config.toml.
-          #
-          # We also must provide the musl system include path, because otherwise clang will default to searching
-          # /usr/include which has incompatible glibc headers.
-          CC: clang
-          TARGET_CFLAGS: --target=${{ matrix.arch }}-unknown-linux-musl -I/usr/include/${{ matrix.arch }}-linux-musl
         run: |-
           cargo build \
             --release \
+            --target-dir target-${{ matrix.arch }} \
             --target ${{ matrix.arch }}-unknown-linux-musl \
             --package server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,18 @@ ARG BUILDPLATFORM
 ARG TARGETARCH
 WORKDIR /work
 
-# Copy in the already-built target/ directory from the build context
-COPY target ./target
+# Copy in the already-built binary from the build context
+# See .dockerignore for how we filter to just the built binaries
+COPY . .
 
 # Map Docker arch -> Rust triple and stage the correct binary at /server
 RUN set -eux; \
   case "${TARGETARCH}" in \
-  amd64)  T=x86_64-unknown-linux-musl ;; \
-  arm64)  T=aarch64-unknown-linux-musl ;; \
+  amd64)  T=x86_64 ;; \
+  arm64)  T=aarch64 ;; \
   *)      echo "unsupported TARGETARCH=${TARGETARCH}"; exit 1 ;; \
   esac; \
-  install -m 0755 "target/${T}/release/server" /server
+  install -m 0755 "target-${T}/${T}-unknown-linux-musl/release/server" /server
 
 FROM cgr.dev/chainguard/static:latest
 COPY --from=pick /server /


### PR DESCRIPTION
This simplifies cross-compilation while ensuring a cross g++ compiler is available. It also caches each architecture separately.