### PR TITLE
Git ignore target-<arch> directories, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .aws-sam
 /target
+/target-aarch64
+/target-x86_64
 db
 
 # Ignore user-specific modifications to launch environment files


### PR DESCRIPTION
These are created when running the act task, which uses a bind mount.