### PR TITLE
Fix: Update query to fetch all resources invovled in events

### DIFF
--- a/src/query_secrets.surql
+++ b/src/query_secrets.surql
@@ -3,10 +3,28 @@ LET $selected_resource_ids: array<{id: record<resource>}> = SELECT id FROM resou
 LET $other_resources_to_selected_resource_ids: array<{resources: array<record<resource>>}> = SELECT <-event<-resource.id AS resources FROM (SELECT id FROM $selected_resource_ids);
 LET $other_resources_from_selected_resource_ids: array<{resources: array<record<resource>>}> = SELECT ->event->resource.id AS resources FROM (SELECT id FROM $selected_resource_ids);
 
+$events = array::concat(
+    array::flatten(SELECT VALUE <-event.* FROM $selected_resource_ids),
+    array::flatten(SELECT VALUE ->event.* FROM $selected_resource_ids)
+).distinct();
+
+// Get resources from all principal chains
+LET $principal_chain_resources = array::flatten(
+    $events.map(|$event| {
+        RETURN array::flatten(
+            ($event.principal_chains ?? []).map(|$chain| {
+                LET $chain_records = record::id($chain);
+                RETURN $chain_records.map(|$r| type::thing('resource', $r.id));
+            })
+        );
+    })
+).distinct();
+
 LET $resource_ids: set<record<resource>> = array::concat(
     $selected_resource_ids.id,
     array::flatten($other_resources_to_selected_resource_ids.resources),
-    array::flatten($other_resources_from_selected_resource_ids.resources)
+    array::flatten($other_resources_from_selected_resource_ids.resources),
+    $principal_chain_resources,
 ).distinct();
 
 // Add all ancestors of resources. This is tricky because SurrealQL does not
@@ -22,8 +40,3 @@ $resource_ids = $resource_ids.fold($resource_ids, |$resource_ids: set<record<res
 });
 
 $resources = SELECT * FROM resource WHERE id INSIDE $resource_ids;
-
-$events = array::concat(
-    array::flatten(SELECT VALUE <-event.* FROM $selected_resource_ids),
-    array::flatten(SELECT VALUE ->event.* FROM $selected_resource_ids)
-).distinct();


### PR DESCRIPTION
We don't seem to have tests around this so for now, I've confirmed the behavior manually