### PR TITLE
Remove the concept of "endpoints" for self-hosted backends

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -93,6 +93,10 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.OCI_REPO }}
+          tags: |-
+            ${{
+              github.ref == 'refs/heads/main' && env.OCI_REPO ||
+              steps.meta.outputs.tags
+            }}
           labels: ${{ env.ACT != 'true' && steps.meta.outputs.labels }}
           push: ${{ env.ACT != 'true' }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,6 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "COLORTERM": "truecolor",
-        "ENDPOINT": "http://localhost:5732",
         "RUST_BACKTRACE": "1"
       },
       // Additional environment variables may be defined here, see template file

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ migrator = { path = "migrator" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 surrealdb = { version = "= 2.3.7", features = ["rustls"] }
-tokio = { version = "1.47.1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.47.1", default-features = false, features = ["macros", "rt-multi-thread", "signal"] }
 tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -eux; \
   install -m 0755 "target/${T}-unknown-linux-gnu/release/server" /server
 
 FROM cgr.dev/chainguard/glibc-dynamic:latest
+EXPOSE 5732
 COPY --from=pick /server /
 
 ENTRYPOINT ["/server"]

--- a/migrator/src/accounts.surql
+++ b/migrator/src/accounts.surql
@@ -4,8 +4,8 @@ DEFINE TABLE IF NOT EXISTS account SCHEMAFULL TYPE NORMAL;
 DEFINE FIELD IF NOT EXISTS id ON TABLE account TYPE string READONLY
   // The account ID is a 10-digit number that starts with a non-zero value.
   ASSERT string::len(record::id($this.id)) == 10 && string::is::numeric(record::id($this.id)) && (<number> record::id($this.id) >= 1000000000);
-DEFINE FIELD IF NOT EXISTS endpoint ON TABLE account TYPE string READONLY
-  ASSERT string::is::url($this.endpoint);
+DEFINE FIELD OVERWRITE endpoint ON TABLE account TYPE option<string> READONLY
+  ASSERT type::is::none($this.endpoint) OR string::is::url($this.endpoint);
 DEFINE FIELD OVERWRITE service_data_surrealdb_url ON TABLE account TYPE option<string> READONLY;
 DEFINE FIELD IF NOT EXISTS salt ON TABLE account TYPE bytes READONLY
   ASSERT bytes::len($this.salt) == 16;

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -90,11 +90,6 @@ pub(crate) async fn create_local_account(
 async fn verify_no_local_accounts_exist() -> Result<()> {
     use archodex_error::{anyhow::anyhow, conflict};
 
-    #[derive(Deserialize, PartialEq)]
-    struct AccountsCount {
-        count: u64,
-    }
-
     let local_account_exists: bool = accounts_db()
         .await?
         .query("RETURN COUNT(SELECT id FROM account WHERE deleted_at IS NONE LIMIT 1) > 0")

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -10,7 +10,6 @@ use crate::{
     account::{Account, AccountPublic, AccountQueries},
     auth::DashboardAuth,
     db::{QueryCheckFirstRealError, accounts_db},
-    env::Env,
 };
 
 #[derive(Serialize)]
@@ -63,14 +62,12 @@ pub(crate) async fn create_local_account(
     auth: DashboardAuth,
     req: CreateAccountRequest,
 ) -> Result<Json<AccountPublic>> {
-    let endpoint = Env::endpoint();
-
     verify_no_local_accounts_exist().await?;
 
     let principal = auth.principal();
     principal.ensure_user_record_exists().await?;
 
-    let account = Account::new(endpoint.to_string(), req.account_id, principal.clone())
+    let account = Account::new(req.account_id, principal.clone())
         .await
         .context("Failed to create new account")?;
 
@@ -119,6 +116,8 @@ pub(crate) async fn create_archodex_com_account(
     auth: DashboardAuth,
     req: CreateAccountRequest,
 ) -> Result<Json<AccountPublic>> {
+    use crate::env::Env;
+
     let endpoint = if let Some(endpoint) = req.endpoint {
         endpoint
     } else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,6 +7,7 @@ pub struct Env {
     #[cfg(not(feature = "archodex-com"))]
     surrealdb_url: String,
     surrealdb_creds: Option<surrealdb::opt::auth::Root<'static>>,
+    #[cfg(feature = "archodex-com")]
     endpoint: String,
     cognito_user_pool_id: String,
     cognito_client_id: String,
@@ -31,8 +32,6 @@ impl Env {
                 .expect("Failed to parse PORT env var as u16");
 
             let archodex_domain = env_with_default_for_empty("ARCHODEX_DOMAIN", "archodex.com");
-
-            let endpoint = std::env::var("ENDPOINT").expect("Missing ENDPOINT env var");
 
             #[cfg(not(feature = "archodex-com"))]
             let (_, surrealdb_url) = (
@@ -88,7 +87,8 @@ impl Env {
                 #[cfg(not(feature = "archodex-com"))]
                 surrealdb_url,
                 surrealdb_creds,
-                endpoint: endpoint.clone(),
+                #[cfg(feature = "archodex-com")]
+                endpoint: std::env::var("ENDPOINT").expect("Missing ENDPOINT env var"),
                 cognito_user_pool_id: env_with_default_for_empty(
                     "COGNITO_USER_POOL_ID",
                     "us-west-2_Mf1K95El6",
@@ -128,6 +128,7 @@ impl Env {
         Self::get().surrealdb_creds
     }
 
+    #[cfg(feature = "archodex-com")]
     pub(crate) fn endpoint() -> &'static str {
         Self::get().endpoint.as_str()
     }

--- a/src/report_api_key.proto
+++ b/src/report_api_key.proto
@@ -4,7 +4,7 @@ package archodex.report_api_key;
 
 message ReportApiKey {
   uint32 version = 1; // Always set to 1
-  string endpoint = 2;
+  optional string endpoint = 2;
   bytes account_salt = 3; // Always 16 bytes long
   bytes nonce = 4; // Always 12 bytes long for AES128-GCM
   bytes encrypted_contents = 5;
@@ -17,6 +17,6 @@ message ReportApiKeyEncryptedContents {
 
 message ReportApiKeyEncryptedAAD {
   fixed32 key_id = 1;
-  string endpoint = 2;
+  optional string endpoint = 2;
   bytes account_salt = 3;
 }


### PR DESCRIPTION
We were using the same endpoint configuration to represent the address that the dashboard queries for data and that agents send reports to. But these may be different. For example, running a backend in a Docker container in Docker Desktop will require agents to use one address inside other containers to contact the backend over docker networking, while the browser will need to connect to localhost.

This PR removes the concept of "endpoints" from self-hosted accounts. When registering a self-hosted instance in the dashboard we will still the endpoint that the dashboard uses inside the global account record, but the self-hosted instance's account record will no longer store its own endpoint. Further, report API keys will no longer have the endpoint embedded within them for self-hosted accounts.

This PR also:
- Fixes the OCI image tag pushed on branch builds
- Adds the self-hosted port to the Dockerfile (this is more a documentation thing than a change in any behavior)
- Watches for Ctrl+C (sigint) to shut down when running as PID 1 inside a container
- Removes an unused struct (need to figure out how this is getting past the lint check job...)